### PR TITLE
fix User component problem with Ruslan

### DIFF
--- a/src/components/User.js
+++ b/src/components/User.js
@@ -1,13 +1,17 @@
 import { Box, Button, Card, CardContent, CardMedia, CircularProgress, Typography } from '@mui/material'
 import React, { useEffect, useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useParams } from 'react-router-dom'
 
 const RouteLink = React.forwardRef((itemProps, ref) => <Link ref={ref} {...itemProps} role={undefined} />);
 
 const User = () => {
-  const { state: { username } = {} } = useLocation()
+  const { id: username } = useParams()
   const [isLoading, setIsLoading] = useState(true)
   const [user, setUser] = useState({})
+
+  if(!username) {
+    return null;
+  }
 
   useEffect(() => {
     if (isLoading) {


### PR DESCRIPTION
As username state passed from landing page can't be relied on direct URL navigation, modified the approach as suggested by Ruslan during the code review retried the "id" from the URL params and used it to fetch user details page data.
Additionally added an "if" block to prevent errors thrown in the browser console.